### PR TITLE
No padding when sequence doesn't start with a 0

### DIFF
--- a/source/clique/__init__.py
+++ b/source/clique/__init__.py
@@ -11,7 +11,7 @@ from .error import CollectionError
 
 
 #: Pattern for matching an index with optional padding.
-DIGITS_PATTERN = '(?P<index>(?P<padding>0*)\d+)'
+DIGITS_PATTERN = '(?P<index>(?P<padding>\d*)\d+)'
 
 #: Common patterns that can be passed to :py:func:`~clique.assemble`.
 PATTERNS = {


### PR DESCRIPTION
Hi

I wasn't sure how to create an issue on here, or even if my result was an issue.
So I've created this pull request, the change fixes the bug I had described bellow, but hasn't been tested with any other circumstances.

bug was:
`files = ['04_020_pipes_faf_Compositing__v008_1001.tga',
         '04_020_pipes_faf_Compositing__v008_1002.tga',
         '04_020_pipes_faf_Compositing__v008_1003.tga',
         '04_020_pipes_faf_Compositing__v008_1004.tga']`
`collection, remainder = clique.assemble(files)`
`-> [<Collection "04_020_pipes_faf_Compositing__v008_%d.tga [1001-1004]">]`

I only get a %d despite it being a 4 digit number. The change produces the correct result in this situation.

Thanks
Phil
